### PR TITLE
New channel : Microsoft Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cucumber-export
 
-This cucumber formatter works well with cucumber versions from  6.x inclusive
+This cucumber formatter works well with cucumber versions from 6.x inclusive
 
 ## Installation
 
@@ -11,7 +11,7 @@ npm install @restqa/cucumber-export
 ## API
 
 ```js
-const { getFormatter } = require('@restqa/cucumber-export')
+const { getFormatter } = require('@restqa/cucumber-export');
 ```
 
 The `getFormatter` object expose a function receving your exports options.
@@ -19,7 +19,7 @@ All The options are shared below.
 
 ### cucumberExport.getFormatter([options])
 
-Returns a cucumber formatter where the result will be pre-formatted and transferred 
+Returns a cucumber formatter where the result will be pre-formatted and transferred
 to the selected destination.
 
 #### Options
@@ -52,7 +52,7 @@ Represent a environment of the current test suite (example: uat)
 
 ##### outputs \<array> (required)
 
-You can configure different output, the available output reporters are : 
+You can configure different output, the available output reporters are :
 
 ###### File
 
@@ -102,9 +102,31 @@ Receive a notification on slack about you test report
   }
 }
 ```
+
 _Example_:
 
 ![slack notification](https://restqa.io/assets/img/utils/cucumber-export-slack.png)
+
+###### Microsoft Teams
+
+Receive a connector card in your Microsoft Teams channel when your test finishes
+
+```
+{
+  type: 'microsoft-teams',
+  enabled: true,
+  config: {
+    url: 'https://outlook.office.com/webhook/xxx/IncomingWebhook/yyy/zzz', // The teams webhook url
+    onlyFailed: true, // Trigger the hook only for test failure  (default: false)
+    showErrors: true,  // Show the error message within teams
+    reportUrl: 'https://www.test.report/{uuid}' // The url to access to your detail test report if you have one
+  }
+}
+```
+
+_Example_:
+
+![teams notification](https://restqa.io/assets/img/utils/cucumber-export-teams.png)
 
 ###### Elastic-Search
 
@@ -129,6 +151,7 @@ Export the result to a remote endpoint in order to generate an html report.
 
 For more information about the generation of the report you can look at the project : https://github.com/restqa/cucumber-html-reporter-server
 Basically you have 2 options to use this reporter.]:
+
 1. Use the Saas version hosted on : html-report.restqa.io (pro: ready, con: data privacy, shared)
 2. Host your own, sotfware available here : https://github.com/restqa/cucumber-html-reporter-server
 
@@ -200,6 +223,16 @@ let envConfig = {
         showErrors: true,  // Show the error message within slack
         reportUrl: 'https://www.test.report/{uuid}' // The url to access to your detail test report if you have one
       }
+    },
+    {
+      type: 'microsoft-teams',
+      enabled: true,
+      config: {
+        url: 'https://outlook.office.com/webhook/xxx/IncomingWebhook/yyy/zzz', // The teams webhook url
+        onlyFailed: true, // Trigger the hook only for test failure  (default: false)
+        showErrors: true,  // Show the error message within teams
+        reportUrl: 'https://www.test.report/{uuid}' // The url to access to your detail test report if you have one
+      }
     }
   ]
 }
@@ -214,7 +247,6 @@ You can now run cucumber-js with the just created formatter
 `cucumber-js -f ./restqa-formatter.js:restqa.log`
 
 > It's important to defined formatter export path to have access the logs, you can refer to the cucumber-js documentation (https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md#formats)'
-
 
 ## License
 

--- a/src/reports/index.js
+++ b/src/reports/index.js
@@ -3,5 +3,6 @@ module.exports = {
   'http-html-report': require('./http-html-report'),
   'elastic-search': require('./elastic-search'),
   file: require('./file'),
-  slack: require('./slack')
+  slack: require('./slack'),
+  'microsoft-teams': require('./microsoft-teams')
 }

--- a/src/reports/index.test.js
+++ b/src/reports/index.test.js
@@ -1,7 +1,14 @@
 describe('#services - Channels', () => {
   test('init module', () => {
     const index = require('./index')
-    expect(Object.keys(index).length).toEqual(5)
-    expect(Object.keys(index)).toEqual(['http', 'http-html-report', 'elastic-search', 'file', 'slack'])
+    expect(Object.keys(index).length).toEqual(6)
+    expect(Object.keys(index)).toEqual([
+      'http',
+      'http-html-report',
+      'elastic-search',
+      'file',
+      'slack',
+      'microsoft-teams'
+    ])
   })
 })

--- a/src/reports/microsoft-teams.js
+++ b/src/reports/microsoft-teams.js
@@ -1,0 +1,138 @@
+const got = require('got')
+const Errors = require('../errors')
+
+module.exports = function (config, result) {
+  return new Promise((resolve, reject) => {
+    try {
+      if (undefined === config.onlyFailed) {
+        config.onlyFailed = true
+      }
+
+      if (!config.url) { return reject(new Error('config.url is required for the "microsoft-teams" report')) }
+
+      const url = new URL(config.url)
+
+      if (config.onlyFailed === true && result.success === true) {
+        return resolve(
+          '[MICROSOFT TEAMS] No notification is required because eveything is fine :)'
+        )
+      }
+
+      const getStepsError = function () {
+        return result.features
+          .filter((_) => !_.result)
+          .map((feature) => {
+            return feature.elements
+              .filter((_) => !_.result)
+              .map((scenario) => {
+                const step = scenario.steps.find((_) => _.result.status === 'failed')
+                if (!step) return
+                return {
+                  activityTitle: `📕 *Feature*: ${feature.feature_name}`,
+                  facts: [
+                    {
+                      name: 'Scenario',
+                      value: scenario.name
+                    },
+                    {
+                      name: 'Failed step',
+                      value: `${step.keyword} ${step.name} (Line ${step.line})`
+                    },
+                    {
+                      name: 'Error message',
+                      value: `\n\n    ${step.result.error_message.split('\n').join('\n    ')}`
+                    }
+                  ],
+                  markdown: true
+                }
+              })
+              .filter((_) => _)
+          })
+          .flat()
+      }
+
+      const status = result.success ? 'passed' : 'failed'
+      let sections = [
+        {
+          activityTitle: 'Details',
+          activitySubtitle: '*Powered By:* [@restqa](https://restqa.io|@restqa)',
+          activityImage: `https://restqa.io/assets/img/utils/restqa-logo-${status.toLowerCase()}.png`,
+          activityText: `Name: ${result.name}\n\nEnvironment: ${result.env || ''}\n\nKey: ${
+            result.key || ''
+          }\n\nExecution Id: ${result.id}\n\n`,
+          facts: [
+            {
+              name: 'Scenarios',
+              value: ''
+            },
+            {
+              name: '• Passed',
+              value: `${result.scenarios.passed}`
+            },
+            {
+              name: '• Failed',
+              value: `${result.scenarios.failed}`
+            },
+            {
+              name: '• Skipped',
+              value: `${result.scenarios.skipped}`
+            },
+            {
+              name: '• Undefined',
+              value: `${result.scenarios.undefined}`
+            }
+          ],
+          markdown: true
+        }
+      ]
+
+      if (config.showErrors) {
+        sections = sections.concat(getStepsError())
+      }
+
+      const potentialAction = []
+      if (config.reportUrl) {
+        potentialAction.push({
+          '@type': 'OpenUri',
+          name: '📊 View test report',
+          targets: [
+            {
+              os: 'default',
+              uri: `${config.reportUrl.replace('{uuid}', result.id)}`
+            }
+          ]
+        })
+      }
+
+      const data = {
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        themeColor: result.success ? '007a5a' : 'ff0000',
+        summary: `${result.name} ${status}`,
+        title: `Test suite ${result.name ? `"${result.name}" ` : ''}results`,
+        text: `The test suite **${status} (${result.passed}/${result.total})**`,
+        sections,
+        potentialAction
+      }
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port,
+        protocol: url.protocol,
+        pathname: url.pathname,
+        method: 'POST',
+        body: JSON.stringify(data)
+      }
+
+      got(options)
+        .then((res) => {
+          resolve(`[MICROSOFT TEAMS REPORT][${res.statusCode}] - ${config.url}`)
+        })
+        .catch((err) => {
+          reject(new Errors.HTTP('MICROSOFT TEAMS REPORT', err))
+        })
+    } catch (e) {
+      reject(new Errors.DEFAULT('MICROSOFT TEAMS REPORT', e))
+    }
+  })
+}

--- a/src/reports/microsoft-teams.js
+++ b/src/reports/microsoft-teams.js
@@ -40,6 +40,10 @@ module.exports = function (config, result) {
                     },
                     {
                       name: 'Error message',
+                      // The formatting for the below value is the 'fix' for a bug in code display
+                      // on the Teams platform. A double newline and double indent will trigger
+                      // a code block that wraps your code rather than letting it overflow off
+                      // the screen.
                       value: `\n\n    ${step.result.error_message.split('\n').join('\n    ')}`
                     }
                   ],

--- a/src/reports/microsoft-teams.test.js
+++ b/src/reports/microsoft-teams.test.js
@@ -1,0 +1,283 @@
+let testResult = {}
+
+beforeEach(() => {
+  jest.resetModules()
+  testResult = {
+    id: 'xxx-yyy-zzz',
+    name: 'my test result',
+    env: 'local',
+    key: 'MY-KEY',
+    success: true,
+    total: 10,
+    passed: 10,
+    failed: 0,
+    scenarios: {
+      passed: 50,
+      failed: 0,
+      skipped: 10,
+      undefined: 0
+    }
+  }
+})
+
+describe('#report - MICROSOFT TEAMS', () => {
+  test("Rejected if the config doesn't contain the url", () => {
+    const Teams = require('./microsoft-teams')
+    const config = {}
+    const result = {}
+    expect(Teams(config, result)).rejects.toThrow(
+      new Error('config.url is required for the "microsoft-teams" report')
+    )
+  })
+
+  test('Resolved if the config only specify notification for failure', () => {
+    const got = require('got')
+    jest.mock('got')
+
+    const Teams = require('./microsoft-teams')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: true
+    }
+
+    const result = {
+      success: true
+    }
+
+    expect(Teams(config, result)).resolves.toBe(
+      '[MICROSOFT TEAMS] No notification is required because eveything is fine :)'
+    )
+    expect(got.mock.calls.length).toBe(0)
+  })
+
+  test('Rejected if an issue occured', () => {
+    const Errors = require('../errors')
+
+    const Teams = require('./microsoft-teams')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    testResult.scenarios = null
+
+    expect(Teams(config, testResult)).rejects.toThrow(
+      new Errors.DEFAULT(
+        'MICROSOFT TEAMS REPORT',
+        new Error("Cannot read property 'passed' of null")
+      )
+    )
+  })
+
+  test('Rejected if the request fail', () => {
+    const Errors = require('../errors')
+    const got = require('got')
+    jest.mock('got')
+    const gotError = new Error('got Msg')
+    gotError.response = {
+      statusCode: 503,
+      body: {
+        err: 'foo/bar'
+      }
+    }
+
+    got.mockRejectedValue(gotError)
+
+    const Teams = require('./microsoft-teams')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    expect(Teams(config, testResult)).rejects.toThrow(
+      new Errors.HTTP('MICROSOFT TEAMS REPORT', gotError)
+    )
+
+    const teamsExpect = {
+      '@type': 'MessageCard',
+      '@context': 'http://schema.org/extensions',
+      themeColor: '007a5a',
+      summary: 'my test result passed',
+      title: 'Test suite "my test result" results',
+      text: 'The test suite **passed (10/10)**',
+      sections: [
+        {
+          activityTitle: 'Details',
+          activitySubtitle: '*Powered By:* [@restqa](https://restqa.io|@restqa)',
+          activityImage: 'https://restqa.io/assets/img/utils/restqa-logo-passed.png',
+          activityText:
+            'Name: my test result\n\nEnvironment: local\n\n' +
+            'Key: MY-KEY\n\nExecution Id: xxx-yyy-zzz\n\n',
+          facts: [
+            {
+              name: 'Scenarios',
+              value: ''
+            },
+            {
+              name: '• Passed',
+              value: '50'
+            },
+            {
+              name: '• Failed',
+              value: '0'
+            },
+            {
+              name: '• Skipped',
+              value: '10'
+            },
+            {
+              name: '• Undefined',
+              value: '0'
+            }
+          ],
+          markdown: true
+        }
+      ],
+      potentialAction: []
+    }
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(teamsExpect)
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+
+  test('Success case with config.showError = true, and report link)', () => {
+    const got = require('got')
+    jest.mock('got')
+    got.mockResolvedValue({
+      statusCode: 201,
+      body: {
+        result: 'ok'
+      }
+    })
+
+    const Teams = require('./microsoft-teams')
+
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false,
+      showErrors: true,
+      reportUrl: 'http://url-of-the-report/{uuid}'
+    }
+
+    testResult.success = false
+    testResult.passed = 9
+    testResult.failed = 1
+    testResult.scenarios.passed = 49
+    testResult.scenarios.failed = 1
+    testResult.features = [
+      {
+        feature_name: 'Feature name',
+        elements: [
+          {
+            name: 'This is scenario name',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue',
+                line: 45,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    expect(Teams(config, testResult)).resolves.toBe(
+      '[MICROSOFT TEAMS REPORT][201] - http://my-url.test/report'
+    )
+
+    const teamsExpect = {
+      '@type': 'MessageCard',
+      '@context': 'http://schema.org/extensions',
+      themeColor: 'ff0000',
+      summary: 'my test result failed',
+      title: 'Test suite "my test result" results',
+      text: 'The test suite **failed (9/10)**',
+      sections: [
+        {
+          activityTitle: 'Details',
+          activitySubtitle: '*Powered By:* [@restqa](https://restqa.io|@restqa)',
+          activityImage: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png',
+          activityText:
+            'Name: my test result\n\nEnvironment: local\n\nKey: MY-KEY\n\nExecution Id: xxx-yyy-zzz\n\n',
+          facts: [
+            {
+              name: 'Scenarios',
+              value: ''
+            },
+            {
+              name: '• Passed',
+              value: '49'
+            },
+            {
+              name: '• Failed',
+              value: '1'
+            },
+            {
+              name: '• Skipped',
+              value: '10'
+            },
+            {
+              name: '• Undefined',
+              value: '0'
+            }
+          ],
+          markdown: true
+        },
+        {
+          activityTitle: '📕 *Feature*: Feature name',
+          facts: [
+            {
+              name: 'Scenario',
+              value: 'This is scenario name'
+            },
+            {
+              name: 'Failed step',
+              value: 'When i have an issue (Line 45)'
+            },
+            {
+              name: 'Error message',
+              value: '\n\n    Not working'
+            }
+          ],
+          markdown: true
+        }
+      ],
+      potentialAction: [
+        {
+          '@type': 'OpenUri',
+          name: '📊 View test report',
+          targets: [
+            {
+              os: 'default',
+              uri: 'http://url-of-the-report/xxx-yyy-zzz'
+            }
+          ]
+        }
+      ]
+    }
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(teamsExpect)
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+})


### PR DESCRIPTION
I've added MS Teams incoming webhook integration, based off of the existing slack adapter.

There has been some formatting changes, you can take a preview here:

![screenshot-teams microsoft com-2020 08 02-23_33_26](https://user-images.githubusercontent.com/8168401/89122087-a1e08a00-d518-11ea-8b13-18a3c826232c.png)

The only issue I ran into was with the preformatted code block, which teams does not seem to support very well within one of it's `facts`. You'll notice a double border around it. I've tried various combinations of `<pre>`, triple backtick etc. but there was no way to get the correct formatting over multiple lines. I have thus implemented this workaround.

Please add the following image to your restqa site assets if you integrate my changes for the readme `cucumber-export-teams.png`:

![cucumber-export-teams](https://user-images.githubusercontent.com/8168401/89122118-eb30d980-d518-11ea-9c60-a9256f7d9920.png)
