### PR TITLE
New channel : Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ _Example_:
 
 ![teams notification](https://restqa.io/assets/img/utils/cucumber-export-teams.png)
 
+###### Discord
+
+Receive a message in your Discord channel when your test finishes via webhook. See how to set up the webhook bot here: 
+
+```
+{
+  type: 'discord',
+  enabled: true,
+  config: {
+    url: 'https://discordapp.com/api/webhooks/111111111111111/abc-def_ghijklmnopqrstxyz', // The discord webhook url
+    onlyFailed: false, // Trigger the hook only for test failure  (default: false)
+    showErrors: true,  // Show the error message within slack
+    reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one,
+    tts: false, // enable TTS for the message false by default
+    username: 'bot-name' //  alternative name for bot, uses the name it has in discord UI by default if nothing specified
+  }
+}
+```
+
+_Example_:
+
+![discord notification](https://restqa.io/assets/img/utils/cucumber-export-discord.png)
+
 ###### Line
 
 Receive a notification on line about you test report

--- a/README.md
+++ b/README.md
@@ -131,18 +131,18 @@ _Example_:
 
 ###### Discord
 
-Receive a message in your Discord channel when your test finishes via webhook. See how to set up the webhook bot here: 
+Receive a message in your Discord channel when your test finishes via webhook. See how to set up the webhook bot here:
 
 ```
 {
   type: 'discord',
   enabled: true,
   config: {
-    url: 'https://discordapp.com/api/webhooks/111111111111111/abc-def_ghijklmnopqrstxyz', // The discord webhook url
+    url: 'https://discordapp.com/api/webhooks/xxx/yyy', // The discord webhook url
     onlyFailed: false, // Trigger the hook only for test failure  (default: false)
     showErrors: true,  // Show the error message within slack
     reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one,
-    tts: false, // enable TTS for the message false by default
+    tts: false, // enable TTS for the message, false by default
     username: 'bot-name' //  alternative name for bot, uses the name it has in discord UI by default if nothing specified
   }
 }
@@ -169,7 +169,6 @@ Receive a notification on line about you test report
 ```
 
 In order to get the token for the nofify line app, take a look at : https://notify-bot.line.me/en/
-
 
 _Example_:
 
@@ -289,6 +288,18 @@ let envConfig = {
         onlyFailed: true, // Trigger the hook only for test failure  (default: false)
         reportUrl: 'https://www.test.report/{uuid}' // The url to access to your detail test report if you have one
       }
+    },
+    {
+      type: 'discord',
+      enabled: true,
+      config: {
+        url: 'https://discordapp.com/api/webhooks/xxx/yyy', // The discord webhook url
+        onlyFailed: false, // Trigger the hook only for test failure  (default: false)
+        showErrors: true,  // Show the error message within slack
+        reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one,
+        tts: false, // enable TTS for the message, false by default
+        username: 'bot-name' //  alternative name for bot, uses the name it has in discord UI by default if nothing specified
+      }
     }
   ]
 }
@@ -306,15 +317,13 @@ You can now run cucumber-js with the just created formatter
 
 ### TODO
 
-Creates channels for :
+Create channels for :
 
-* Mattermost
-* Rocket chat
-* Discord
-* google hangout
-* Prometheus
-* Grafana Loki
-
+- Mattermost
+- Rocket chat
+- Google Hangouts
+- Prometheus
+- Grafana Loki
 
 ## License
 

--- a/src/reports/discord.js
+++ b/src/reports/discord.js
@@ -28,7 +28,7 @@ module.exports = function (config, result) {
                 const step = scenario.steps.find((_) => _.result.status === 'failed')
                 if (!step) return
                 return {
-                  name: `📕 **Feature**: ${feature.feature_name}`.slice(0, 256),
+                  name: `📕 **Feature**: ${feature.feature_name}`.slice(0, 256), // Discord supports up to 256 charcters in field name
                   value: [
                     `**Scenario**: ${scenario.name}`,
                     `**Failed step**: ${step.keyword} ${step.name} (Line ${step.line})`,
@@ -36,7 +36,7 @@ module.exports = function (config, result) {
                     '----'
                   ]
                     .join('\n')
-                    .slice(0, 2048)
+                    .slice(0, 1024) // Discord supports up to 1024 characters in field value
                 }
               })
               .filter((_) => _)

--- a/src/reports/discord.js
+++ b/src/reports/discord.js
@@ -8,78 +8,80 @@ module.exports = function (config, result) {
         config.onlyFailed = true
       }
 
-      if (!config.url) { return reject(new Error('config.url is required for the "discord" report')) }
+      if (!config.url) {
+        return reject(new Error('config.url is required for the "discord" report'))
+      }
 
       const url = new URL(config.url)
 
       if (config.onlyFailed === true && result.success === true) {
-        return resolve(
-          '[DISCORD] No notification is required because eveything is fine :)'
-        )
+        return resolve('[DISCORD] No notification is required because eveything is fine :)')
       }
 
       const getStepsError = function () {
-        return result
-          .features
-          .filter(_ => !_.result)
-          .map(feature => {
-            return feature
-              .elements
-              .filter(_ => !_.result)
-              .map(scenario => {
-                const step = scenario.steps.find(_ => _.result.status === 'failed')
+        return result.features
+          .filter((_) => !_.result)
+          .map((feature) => {
+            return feature.elements
+              .filter((_) => !_.result)
+              .map((scenario) => {
+                const step = scenario.steps.find((_) => _.result.status === 'failed')
                 if (!step) return
                 return {
                   name: `📕 **Feature**: ${feature.feature_name}`.slice(0, 256),
                   value: [
-                      `**Scenario**: ${scenario.name}`,
-                      `**Failed step**: ${step.keyword} ${step.name} (Line ${step.line})`,
-                      `\`\`\` ${step.result.error_message} \`\`\``,
-                      '----'
-                    ].join('\n').slice(0, 2048)
+                    `**Scenario**: ${scenario.name}`,
+                    `**Failed step**: ${step.keyword} ${step.name} (Line ${step.line})`,
+                    `\`\`\` ${step.result.error_message} \`\`\``,
+                    '----'
+                  ]
+                    .join('\n')
+                    .slice(0, 2048)
                 }
               })
-              .filter(_ => _)
+              .filter((_) => _)
           })
-          .flat().slice(0, 25)
+          .flat()
+          .slice(0, 25) // Discord supports up to 25 embeds field, need to truncate after
       }
 
       const status = result.success ? 'passed' : 'failed'
-      let embed = {
-          title: `The test suite **${status} (${result.passed}/${result.total})**`,
-          description: `
-          **Name:** ${result.name}
-          **Key:** ${result.key || ''}
-          **Environment:** ${result.env}
-          **Execution Id:** ${result.id}
+      const embed = {
+        title: `The test suite **${status} (${result.passed}/${result.total})**`,
+        description: `**Name:** ${result.name}
+**Key:** ${result.key || ''}
+**Environment:** ${result.env}
+**Execution Id:** ${result.id}
 
-          **Scenarios:**
-          - **Passed:** ${result.scenarios.passed}
-          - **Failed:** ${result.scenarios.failed}
-          - **Skipped:** ${result.scenarios.skipped}
-          - **Undefined:** ${result.scenarios.undefined}
+**Scenarios:**
+- **Passed:** ${result.scenarios.passed}
+- **Failed:** ${result.scenarios.failed}
+- **Skipped:** ${result.scenarios.skipped}
+- **Undefined:** ${result.scenarios.undefined}
 
-          *Powered By:* [@restqa](https://restqa.io)
-          `.slice(0, 2048),
-          thumbnail: {
-            url: `https://restqa.io/assets/img/utils/restqa-logo-${status.toLowerCase()}.png`,
-          },
-          color: result.success ? 31322 : 16711680,
-        }
+*Powered By:* [@restqa](https://restqa.io)`.slice(0, 2048), // Discord supports up to 2048 characters in embeds description
+        thumbnail: {
+          url: `https://restqa.io/assets/img/utils/restqa-logo-${status.toLowerCase()}.png`
+        },
+        color: result.success ? 31322 : 16711680
+      }
 
       if (config.showErrors) {
-        embed.fields = getStepsError();
+        embed.fields = getStepsError()
       }
 
       if (config.reportUrl) {
-        embed.url = config.reportUrl.replace('{uuid}', result.id);
-        embed.description = `[**📊 Access to Test Report**](${config.reportUrl.replace('{uuid}', result.id)})\n`.concat(embed.description);
+        embed.url = config.reportUrl.replace('{uuid}', result.id)
+        embed.description = `[**📊 View test report**](${config.reportUrl.replace(
+          '{uuid}',
+          result.id
+        )})\n`.concat(embed.description)
       }
 
       const data = {
         username: config.username || null,
         tts: config.tts || false,
-        embeds: [embed],
+        embeds: [embed]
       }
 
       const options = {
@@ -90,8 +92,8 @@ module.exports = function (config, result) {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {
-          'Content-Type': `application/json`
-        },
+          'Content-Type': 'application/json'
+        }
       }
 
       got(options)

--- a/src/reports/discord.js
+++ b/src/reports/discord.js
@@ -68,7 +68,7 @@ module.exports = function (config, result) {
         }
 
       if (config.showErrors) {
-        embed.fields = getStepsErrors();
+        embed.fields = getStepsError();
       }
 
       if (config.reportUrl) {

--- a/src/reports/discord.js
+++ b/src/reports/discord.js
@@ -1,0 +1,108 @@
+const got = require('got')
+const Errors = require('../errors')
+
+module.exports = function (config, result) {
+  return new Promise((resolve, reject) => {
+    try {
+      if (undefined === config.onlyFailed) {
+        config.onlyFailed = true
+      }
+
+      if (!config.url) { return reject(new Error('config.url is required for the "discord" report')) }
+
+      const url = new URL(config.url)
+
+      if (config.onlyFailed === true && result.success === true) {
+        return resolve(
+          '[DISCORD] No notification is required because eveything is fine :)'
+        )
+      }
+
+      const getStepsError = function () {
+        return result
+          .features
+          .filter(_ => !_.result)
+          .map(feature => {
+            return feature
+              .elements
+              .filter(_ => !_.result)
+              .map(scenario => {
+                const step = scenario.steps.find(_ => _.result.status === 'failed')
+                if (!step) return
+                return {
+                  name: `📕 **Feature**: ${feature.feature_name}`.slice(0, 256),
+                  value: [
+                      `**Scenario**: ${scenario.name}`,
+                      `**Failed step**: ${step.keyword} ${step.name} (Line ${step.line})`,
+                      `\`\`\` ${step.result.error_message} \`\`\``,
+                      '----'
+                    ].join('\n').slice(0, 2048)
+                }
+              })
+              .filter(_ => _)
+          })
+          .flat().slice(0, 25)
+      }
+
+      const status = result.success ? 'passed' : 'failed'
+      let embed = {
+          title: `The test suite **${status} (${result.passed}/${result.total})**`,
+          description: `
+          **Name:** ${result.name}
+          **Key:** ${result.key || ''}
+          **Environment:** ${result.env}
+          **Execution Id:** ${result.id}
+
+          **Scenarios:**
+          - **Passed:** ${result.scenarios.passed}
+          - **Failed:** ${result.scenarios.failed}
+          - **Skipped:** ${result.scenarios.skipped}
+          - **Undefined:** ${result.scenarios.undefined}
+
+          *Powered By:* [@restqa](https://restqa.io)
+          `.slice(0, 2048),
+          thumbnail: {
+            url: `https://restqa.io/assets/img/utils/restqa-logo-${status.toLowerCase()}.png`,
+          },
+          color: result.success ? 31322 : 16711680,
+        }
+
+      if (config.showErrors) {
+        embed.fields = getStepsErrors();
+      }
+
+      if (config.reportUrl) {
+        embed.url = config.reportUrl.replace('{uuid}', result.id);
+        embed.description = `[**📊 Access to Test Report**](${config.reportUrl.replace('{uuid}', result.id)})\n`.concat(embed.description);
+      }
+
+      const data = {
+        username: config.username || null,
+        tts: config.tts || false,
+        embeds: [embed],
+      }
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port,
+        protocol: url.protocol,
+        pathname: url.pathname,
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: {
+          'Content-Type': `application/json`
+        },
+      }
+
+      got(options)
+        .then((res) => {
+          resolve(`[DISCORD REPORT][${res.statusCode}] - ${config.url}`)
+        })
+        .catch((err) => {
+          reject(new Errors.HTTP('DISCORD REPORT', err))
+        })
+    } catch (e) {
+      reject(new Errors.DEFAULT('DISCORD REPORT', e))
+    }
+  })
+}

--- a/src/reports/discord.test.js
+++ b/src/reports/discord.test.js
@@ -21,11 +21,13 @@ beforeEach(() => {
 })
 
 describe('#report - DISCORD', () => {
-  test('Rejected if the config doesn\'t contain the url', () => {
+  test("Rejected if the config doesn't contain the url", () => {
     const Discord = require('./discord')
     const config = {}
     const result = {}
-    expect(Discord(config, result)).rejects.toThrow(new Error('config.url is required for the "discord" report'))
+    expect(Discord(config, result)).rejects.toThrow(
+      new Error('config.url is required for the "discord" report')
+    )
   })
 
   test('Resolved if the config only specify notification for failure', () => {
@@ -42,7 +44,9 @@ describe('#report - DISCORD', () => {
       success: true
     }
 
-    expect(Discord(config, result)).resolves.toBe('[DISCORD] No notification is required because eveything is fine :)')
+    expect(Discord(config, result)).resolves.toBe(
+      '[DISCORD] No notification is required because eveything is fine :)'
+    )
     expect(got.mock.calls.length).toBe(0)
   })
 
@@ -57,7 +61,9 @@ describe('#report - DISCORD', () => {
 
     testResult.scenarios = null
 
-    expect(Discord(config, testResult)).rejects.toThrow(new Errors.DEFAULT('DISCORD REPORT', new Error('Cannot read property \'passed\' of null')))
+    expect(Discord(config, testResult)).rejects.toThrow(
+      new Errors.DEFAULT('DISCORD REPORT', new Error("Cannot read property 'passed' of null"))
+    )
   })
 
   test('Rejected if the request fail', () => {
@@ -80,31 +86,35 @@ describe('#report - DISCORD', () => {
       onlyFailed: false
     }
 
-    expect(Discord(config, testResult)).rejects.toThrow(new Errors.HTTP('DISCORD REPORT', gotError))
+    expect(Discord(config, testResult)).rejects.toThrow(
+      new Errors.HTTP('DISCORD REPORT', gotError)
+    )
 
     const discordExpect = {
       username: null,
       tts: false,
-      embeds:[{
-        title: "The test suite **passed (10/10)**",
-        description:
-          '\n          ' +
-          '**Name:** my test result\n          ' +
-          '**Key:** MY-KEY\n          ' +
-          '**Environment:** local\n          ' +
-          '**Execution Id:** xxx-yyy-zzz\n\n          ' +
-          '**Scenarios:**\n          ' +
-          '- **Passed:** 50\n          ' +
-          '- **Failed:** 0\n          ' +
-          '- **Skipped:** 10\n          ' +
-          '- **Undefined:** 0\n\n          ' +
-          '*Powered By:* [@restqa](https://restqa.io)\n          ',
-        thumbnail:{
-          url:"https://restqa.io/assets/img/utils/restqa-logo-passed.png"
-        },
-        color: 31322
-    }]
-  }
+      embeds: [
+        {
+          title: 'The test suite **passed (10/10)**',
+          description: `**Name:** my test result
+**Key:** MY-KEY
+**Environment:** local
+**Execution Id:** xxx-yyy-zzz
+
+**Scenarios:**
+- **Passed:** 50
+- **Failed:** 0
+- **Skipped:** 10
+- **Undefined:** 0
+
+*Powered By:* [@restqa](https://restqa.io)`,
+          thumbnail: {
+            url: 'https://restqa.io/assets/img/utils/restqa-logo-passed.png'
+          },
+          color: 31322
+        }
+      ]
+    }
 
     const expectedOptions = {
       hostname: 'my-url.test',
@@ -146,54 +156,67 @@ describe('#report - DISCORD', () => {
     testResult.failed = 1
     testResult.scenarios.passed = 49
     testResult.scenarios.failed = 1
-    testResult.features = [{
-      feature_name: 'Feature name',
-      elements: [{
-        name: 'This is scenario name',
-        steps: [{
-          keyword: 'When',
-          name: 'i have an issue',
-          line: 45,
-          result: {
-            status: 'failed',
-            error_message: 'Not working'
+    testResult.features = [
+      {
+        feature_name: 'Feature name',
+        elements: [
+          {
+            name: 'This is scenario name',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue',
+                line: 45,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working'
+                }
+              }
+            ]
           }
-        }]
-      }]
-    }]
+        ]
+      }
+    ]
 
-    expect(Discord(config, testResult)).resolves.toBe('[DISCORD REPORT][201] - http://my-url.test/report')
+    expect(Discord(config, testResult)).resolves.toBe(
+      '[DISCORD REPORT][201] - http://my-url.test/report'
+    )
 
     const discordExpect = {
       username: null,
       tts: false,
-      embeds:[{
-        title: "The test suite **failed (9/10)**",
-        description:
-          '[**📊 Access to Test Report**](http://url-of-the-report/xxx-yyy-zzz)\n\n          ' +
-          '**Name:** my test result\n          ' +
-          '**Key:** MY-KEY\n          ' +
-          '**Environment:** local\n          ' +
-          '**Execution Id:** xxx-yyy-zzz\n\n          ' +
-          '**Scenarios:**\n          ' +
-          '- **Passed:** 49\n          ' +
-          '- **Failed:** 1\n          ' +
-          '- **Skipped:** 10\n          ' +
-          '- **Undefined:** 0\n\n          ' +
-          '*Powered By:* [@restqa](https://restqa.io)\n          ',
-        thumbnail:{
-          url:"https://restqa.io/assets/img/utils/restqa-logo-failed.png"
-        },
-        color: 16711680,
-        fields:[{
-          name: '📕 **Feature**: Feature name',
-          value: 
-            '**Scenario**: This is scenario name\n' + 
-            '**Failed step**: When i have an issue (Line 45)\n' +
-            '``` Not working ```\n----'
-        }],
-        url: 'http://url-of-the-report/xxx-yyy-zzz'
-      }]
+      embeds: [
+        {
+          title: 'The test suite **failed (9/10)**',
+          description: `[**📊 View test report**](http://url-of-the-report/xxx-yyy-zzz)
+**Name:** my test result
+**Key:** MY-KEY
+**Environment:** local
+**Execution Id:** xxx-yyy-zzz
+
+**Scenarios:**
+- **Passed:** 49
+- **Failed:** 1
+- **Skipped:** 10
+- **Undefined:** 0
+
+*Powered By:* [@restqa](https://restqa.io)`,
+          thumbnail: {
+            url: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png'
+          },
+          color: 16711680,
+          fields: [
+            {
+              name: '📕 **Feature**: Feature name',
+              value: `**Scenario**: This is scenario name
+**Failed step**: When i have an issue (Line 45)
+${'```'} Not working ${'```'}
+----`
+            }
+          ],
+          url: 'http://url-of-the-report/xxx-yyy-zzz'
+        }
+      ]
     }
 
     const expectedOptions = {

--- a/src/reports/discord.test.js
+++ b/src/reports/discord.test.js
@@ -1,0 +1,294 @@
+let testResult = {}
+
+beforeEach(() => {
+  jest.resetModules()
+  testResult = {
+    id: 'xxx-yyy-zzz',
+    name: 'my test result',
+    env: 'local',
+    key: 'MY-KEY',
+    success: true,
+    total: 10,
+    passed: 10,
+    failed: 0,
+    scenarios: {
+      passed: 50,
+      failed: 0,
+      skipped: 10,
+      undefined: 0
+    }
+  }
+})
+
+describe('#report - DISCORD', () => {
+  test('Rejected if the config doesn\'t contain the url', () => {
+    const Discord = require('./discord')
+    const config = {}
+    const result = {}
+    expect(Discord(config, result)).rejects.toThrow(new Error('config.url is required for the "discord" report'))
+  })
+
+  test('Resolved if the config only specify notification for failure', () => {
+    const got = require('got')
+    jest.mock('got')
+
+    const Discord = require('./discord')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: true
+    }
+
+    const result = {
+      success: true
+    }
+
+    expect(Discord(config, result)).resolves.toBe('[DISCORD] No Notification is required because eveything is fine :)')
+    expect(got.mock.calls.length).toBe(0)
+  })
+
+  test('Discord if an issue occured', () => {
+    const Errors = require('../errors')
+
+    const Discord = require('./discord')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    testResult.scenarios = null
+
+    expect(Discord(config, testResult)).rejects.toThrow(new Errors.DEFAULT('DISCORD REPORT', new Error('Cannot read property \'passed\' of null')))
+  })
+
+  test('Rejected if the request fail', () => {
+    const Errors = require('../errors')
+    const got = require('got')
+    jest.mock('got')
+    const gotError = new Error('got Msg')
+    gotError.response = {
+      statusCode: 503,
+      body: {
+        err: 'foo/bar'
+      }
+    }
+
+    got.mockRejectedValue(gotError)
+
+    const Discord = require('./discord')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    expect(Discord(config, testResult)).rejects.toThrow(new Errors.HTTP('DISCORD REPORT', gotError))
+
+    const slackExpect = {
+      attachments: [{
+        color: '#007a5a',
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: 'The test suite *Passed (10/10)*'
+            }
+          },
+          {
+            type: 'section',
+            fields: [
+              {
+                type: 'mrkdwn',
+                text: '*Name:* my test result'
+              },
+              {
+                type: 'mrkdwn',
+                text: '*key:* MY-KEY'
+              },
+              {
+                type: 'mrkdwn',
+                text: '*Environment:* local'
+              },
+              {
+                type: 'mrkdwn',
+                text: '*Execution Id :* xxx-yyy-zzz'
+              }
+            ]
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: '*Scenarios:* \n *  Passed: 50 \n *  Failed: 0 \n *  Skipped: 10 \n * Undefined: 0'
+            },
+            accessory: {
+              type: 'image',
+              image_url: 'https://restqa.io/assets/img/utils/restqa-logo-passed.png',
+              alt_text: 'status'
+            }
+          },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: '*Powered By:*'
+              },
+              {
+                type: 'mrkdwn',
+                text: '<https://restqa.io|@restqa>'
+              }
+            ]
+          }
+        ]
+      }]
+
+    }
+
+  //   const expectedOptions = {
+  //     hostname: 'my-url.test',
+  //     port: '',
+  //     protocol: 'http:',
+  //     pathname: '/report',
+  //     method: 'POST',
+  //     body: JSON.stringify(slackExpect)
+  //   }
+  //   expect(got.mock.calls.length).toBe(1)
+  //   expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  // })
+
+  // test('Success case with config.showError = true, and report link)', () => {
+  //   const got = require('got')
+  //   jest.mock('got')
+  //   got.mockResolvedValue({
+  //     statusCode: 201,
+  //     body: {
+  //       result: 'ok'
+  //     }
+  //   })
+
+  //   const Slack = require('./slack')
+
+  //   const config = {
+  //     url: 'http://my-url.test/report',
+  //     onlyFailed: false,
+  //     showErrors: true,
+  //     reportUrl: 'http://url-of-the-report/{uuid}'
+  //   }
+
+  //   testResult.success = false
+  //   testResult.passed = 9
+  //   testResult.failed = 1
+  //   testResult.scenarios.passed = 49
+  //   testResult.scenarios.failed = 1
+  //   testResult.features = [{
+  //     feature_name: 'Feature name',
+  //     elements: [{
+  //       name: 'This is scenario name',
+  //       steps: [{
+  //         keyword: 'When',
+  //         name: 'i have an issue',
+  //         line: 45,
+  //         result: {
+  //           status: 'failed',
+  //           error_message: 'Not working'
+  //         }
+  //       }]
+  //     }]
+  //   }]
+
+  //   expect(Slack(config, testResult)).resolves.toBe('[SLACK REPORT][201] - http://my-url.test/report')
+
+  //   const slackExpect = {
+  //     attachments: [{
+  //       color: '#ff0000',
+  //       blocks: [
+  //         {
+  //           type: 'section',
+  //           text: {
+  //             type: 'mrkdwn',
+  //             text: 'The test suite *Failed (9/10)*'
+  //           }
+  //         },
+  //         {
+  //           type: 'section',
+  //           fields: [
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '*Name:* my test result'
+  //             },
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '*key:* MY-KEY'
+  //             },
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '*Environment:* local'
+  //             },
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '*Execution Id :* xxx-yyy-zzz'
+  //             }
+  //           ]
+  //         },
+  //         {
+  //           type: 'section',
+  //           text: {
+  //             type: 'mrkdwn',
+  //             text: '*Scenarios:* \n *  Passed: 49 \n *  Failed: 1 \n *  Skipped: 10 \n * Undefined: 0'
+  //           },
+  //           accessory: {
+  //             type: 'image',
+  //             image_url: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png',
+  //             alt_text: 'status'
+  //           }
+  //         },
+  //         {
+  //           type: 'context',
+  //           elements: [
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '*Powered By:*'
+  //             },
+  //             {
+  //               type: 'mrkdwn',
+  //               text: '<https://restqa.io|@restqa>'
+  //             }
+  //           ]
+  //         },
+  //         {
+  //           type: 'section',
+  //           text: {
+  //             type: 'mrkdwn',
+  //             text: [
+  //               '📕 *Feature*: Feature name',
+  //               '*Scenario*: This is scenario name',
+  //               '*Failed step*: When i have an issue (Line 45)',
+  //               '``` Not working ```',
+  //               '----'
+  //             ].join('\n')
+  //           }
+  //         },
+  //         {
+  //           type: 'section',
+  //           text: {
+  //             type: 'mrkdwn',
+  //             text: '📊  <http://url-of-the-report/xxx-yyy-zzz|Acccess to the Test report>'
+  //           }
+  //         }
+  //       ]
+  //     }]
+
+  //   }
+
+  //   const expectedOptions = {
+  //     hostname: 'my-url.test',
+  //     port: '',
+  //     protocol: 'http:',
+  //     pathname: '/report',
+  //     method: 'POST',
+  //     body: JSON.stringify(slackExpect)
+  //   }
+  //   expect(got.mock.calls.length).toBe(1)
+  //   expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  // })
+})

--- a/src/reports/discord.test.js
+++ b/src/reports/discord.test.js
@@ -42,7 +42,7 @@ describe('#report - DISCORD', () => {
       success: true
     }
 
-    expect(Discord(config, result)).resolves.toBe('[DISCORD] No Notification is required because eveything is fine :)')
+    expect(Discord(config, result)).resolves.toBe('[DISCORD] No notification is required because eveything is fine :)')
     expect(got.mock.calls.length).toBe(0)
   })
 
@@ -82,213 +82,132 @@ describe('#report - DISCORD', () => {
 
     expect(Discord(config, testResult)).rejects.toThrow(new Errors.HTTP('DISCORD REPORT', gotError))
 
-    const slackExpect = {
-      attachments: [{
-        color: '#007a5a',
-        blocks: [
-          {
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: 'The test suite *Passed (10/10)*'
-            }
-          },
-          {
-            type: 'section',
-            fields: [
-              {
-                type: 'mrkdwn',
-                text: '*Name:* my test result'
-              },
-              {
-                type: 'mrkdwn',
-                text: '*key:* MY-KEY'
-              },
-              {
-                type: 'mrkdwn',
-                text: '*Environment:* local'
-              },
-              {
-                type: 'mrkdwn',
-                text: '*Execution Id :* xxx-yyy-zzz'
-              }
-            ]
-          },
-          {
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: '*Scenarios:* \n *  Passed: 50 \n *  Failed: 0 \n *  Skipped: 10 \n * Undefined: 0'
-            },
-            accessory: {
-              type: 'image',
-              image_url: 'https://restqa.io/assets/img/utils/restqa-logo-passed.png',
-              alt_text: 'status'
-            }
-          },
-          {
-            type: 'context',
-            elements: [
-              {
-                type: 'mrkdwn',
-                text: '*Powered By:*'
-              },
-              {
-                type: 'mrkdwn',
-                text: '<https://restqa.io|@restqa>'
-              }
-            ]
-          }
-        ]
-      }]
+    const discordExpect = {
+      username: null,
+      tts: false,
+      embeds:[{
+        title: "The test suite **passed (10/10)**",
+        description:
+          '\n          ' +
+          '**Name:** my test result\n          ' +
+          '**Key:** MY-KEY\n          ' +
+          '**Environment:** local\n          ' +
+          '**Execution Id:** xxx-yyy-zzz\n\n          ' +
+          '**Scenarios:**\n          ' +
+          '- **Passed:** 50\n          ' +
+          '- **Failed:** 0\n          ' +
+          '- **Skipped:** 10\n          ' +
+          '- **Undefined:** 0\n\n          ' +
+          '*Powered By:* [@restqa](https://restqa.io)\n          ',
+        thumbnail:{
+          url:"https://restqa.io/assets/img/utils/restqa-logo-passed.png"
+        },
+        color: 31322
+    }]
+  }
 
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(discordExpect),
+      headers: {
+        'Content-Type': 'application/json'
+      }
     }
 
-  //   const expectedOptions = {
-  //     hostname: 'my-url.test',
-  //     port: '',
-  //     protocol: 'http:',
-  //     pathname: '/report',
-  //     method: 'POST',
-  //     body: JSON.stringify(slackExpect)
-  //   }
-  //   expect(got.mock.calls.length).toBe(1)
-  //   expect(got.mock.calls[0][0]).toEqual(expectedOptions)
-  // })
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
 
-  // test('Success case with config.showError = true, and report link)', () => {
-  //   const got = require('got')
-  //   jest.mock('got')
-  //   got.mockResolvedValue({
-  //     statusCode: 201,
-  //     body: {
-  //       result: 'ok'
-  //     }
-  //   })
+  test('Success case with config.showError = true, and report link)', () => {
+    const got = require('got')
+    jest.mock('got')
+    got.mockResolvedValue({
+      statusCode: 201,
+      body: {
+        result: 'ok'
+      }
+    })
 
-  //   const Slack = require('./slack')
+    const Discord = require('./discord')
 
-  //   const config = {
-  //     url: 'http://my-url.test/report',
-  //     onlyFailed: false,
-  //     showErrors: true,
-  //     reportUrl: 'http://url-of-the-report/{uuid}'
-  //   }
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false,
+      showErrors: true,
+      reportUrl: 'http://url-of-the-report/{uuid}'
+    }
 
-  //   testResult.success = false
-  //   testResult.passed = 9
-  //   testResult.failed = 1
-  //   testResult.scenarios.passed = 49
-  //   testResult.scenarios.failed = 1
-  //   testResult.features = [{
-  //     feature_name: 'Feature name',
-  //     elements: [{
-  //       name: 'This is scenario name',
-  //       steps: [{
-  //         keyword: 'When',
-  //         name: 'i have an issue',
-  //         line: 45,
-  //         result: {
-  //           status: 'failed',
-  //           error_message: 'Not working'
-  //         }
-  //       }]
-  //     }]
-  //   }]
+    testResult.success = false
+    testResult.passed = 9
+    testResult.failed = 1
+    testResult.scenarios.passed = 49
+    testResult.scenarios.failed = 1
+    testResult.features = [{
+      feature_name: 'Feature name',
+      elements: [{
+        name: 'This is scenario name',
+        steps: [{
+          keyword: 'When',
+          name: 'i have an issue',
+          line: 45,
+          result: {
+            status: 'failed',
+            error_message: 'Not working'
+          }
+        }]
+      }]
+    }]
 
-  //   expect(Slack(config, testResult)).resolves.toBe('[SLACK REPORT][201] - http://my-url.test/report')
+    expect(Discord(config, testResult)).resolves.toBe('[DISCORD REPORT][201] - http://my-url.test/report')
 
-  //   const slackExpect = {
-  //     attachments: [{
-  //       color: '#ff0000',
-  //       blocks: [
-  //         {
-  //           type: 'section',
-  //           text: {
-  //             type: 'mrkdwn',
-  //             text: 'The test suite *Failed (9/10)*'
-  //           }
-  //         },
-  //         {
-  //           type: 'section',
-  //           fields: [
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '*Name:* my test result'
-  //             },
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '*key:* MY-KEY'
-  //             },
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '*Environment:* local'
-  //             },
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '*Execution Id :* xxx-yyy-zzz'
-  //             }
-  //           ]
-  //         },
-  //         {
-  //           type: 'section',
-  //           text: {
-  //             type: 'mrkdwn',
-  //             text: '*Scenarios:* \n *  Passed: 49 \n *  Failed: 1 \n *  Skipped: 10 \n * Undefined: 0'
-  //           },
-  //           accessory: {
-  //             type: 'image',
-  //             image_url: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png',
-  //             alt_text: 'status'
-  //           }
-  //         },
-  //         {
-  //           type: 'context',
-  //           elements: [
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '*Powered By:*'
-  //             },
-  //             {
-  //               type: 'mrkdwn',
-  //               text: '<https://restqa.io|@restqa>'
-  //             }
-  //           ]
-  //         },
-  //         {
-  //           type: 'section',
-  //           text: {
-  //             type: 'mrkdwn',
-  //             text: [
-  //               '📕 *Feature*: Feature name',
-  //               '*Scenario*: This is scenario name',
-  //               '*Failed step*: When i have an issue (Line 45)',
-  //               '``` Not working ```',
-  //               '----'
-  //             ].join('\n')
-  //           }
-  //         },
-  //         {
-  //           type: 'section',
-  //           text: {
-  //             type: 'mrkdwn',
-  //             text: '📊  <http://url-of-the-report/xxx-yyy-zzz|Acccess to the Test report>'
-  //           }
-  //         }
-  //       ]
-  //     }]
+    const discordExpect = {
+      username: null,
+      tts: false,
+      embeds:[{
+        title: "The test suite **failed (9/10)**",
+        description:
+          '[**📊 Access to Test Report**](http://url-of-the-report/xxx-yyy-zzz)\n\n          ' +
+          '**Name:** my test result\n          ' +
+          '**Key:** MY-KEY\n          ' +
+          '**Environment:** local\n          ' +
+          '**Execution Id:** xxx-yyy-zzz\n\n          ' +
+          '**Scenarios:**\n          ' +
+          '- **Passed:** 49\n          ' +
+          '- **Failed:** 1\n          ' +
+          '- **Skipped:** 10\n          ' +
+          '- **Undefined:** 0\n\n          ' +
+          '*Powered By:* [@restqa](https://restqa.io)\n          ',
+        thumbnail:{
+          url:"https://restqa.io/assets/img/utils/restqa-logo-failed.png"
+        },
+        color: 16711680,
+        fields:[{
+          name: '📕 **Feature**: Feature name',
+          value: 
+            '**Scenario**: This is scenario name\n' + 
+            '**Failed step**: When i have an issue (Line 45)\n' +
+            '``` Not working ```\n----'
+        }],
+        url: 'http://url-of-the-report/xxx-yyy-zzz'
+      }]
+    }
 
-  //   }
-
-  //   const expectedOptions = {
-  //     hostname: 'my-url.test',
-  //     port: '',
-  //     protocol: 'http:',
-  //     pathname: '/report',
-  //     method: 'POST',
-  //     body: JSON.stringify(slackExpect)
-  //   }
-  //   expect(got.mock.calls.length).toBe(1)
-  //   expect(got.mock.calls[0][0]).toEqual(expectedOptions)
-  // })
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(discordExpect),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
 })

--- a/src/reports/index.js
+++ b/src/reports/index.js
@@ -5,5 +5,6 @@ module.exports = {
   file: require('./file'),
   slack: require('./slack'),
   'microsoft-teams': require('./microsoft-teams'),
+  discord: require('./discord'),
   line: require('./line')
 }

--- a/src/reports/index.test.js
+++ b/src/reports/index.test.js
@@ -1,7 +1,7 @@
 describe('#services - Channels', () => {
   test('init module', () => {
     const index = require('./index')
-    expect(Object.keys(index).length).toEqual(7)
+    expect(Object.keys(index).length).toEqual(8)
     expect(Object.keys(index)).toEqual([
       'http',
       'http-html-report',
@@ -9,6 +9,7 @@ describe('#services - Channels', () => {
       'file',
       'slack',
       'microsoft-teams',
+      'discord',
       'line'
     ])
   })


### PR DESCRIPTION
This pull adds an adapter for discord.

There are limitations in discord's rich messages which constrain message length.

The currently implemented behaviour is to truncate when the limit is reached, otherwise discord will respond with a 400 error to your incoming webhook request.

This in effect limits the number of failed sections able to be displayed to 25 and imposes character limits in the errors to 1024 characters.

Other such limits are commented in the code but these are the main ones. The report link should mitigate the need for any more information than 25 test failures.