### PR TITLE
New channel : Mattermost

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,46 @@ _Example_:
 
 ![line notification](https://restqa.io/assets/img/utils/cucumber-export-line.jpg)
 
+###### Mattermost
+
+Receive a notification in your Mattermost channel when your test finishes
+
+```
+{
+  type: 'mattermost',
+  enabled: true,
+  config: {
+    url: 'https://your-mattermost-url/webhooks/xxx',
+    onlyFailed: true // Trigger the hook only for test failure  (default: false),
+    showErrors: true // Show the error message within Mattermost,
+    reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one
+    channel: 'town-square', // The channel to send messages to
+    username: 'restqa-formatter', // Username to post as (only works if bot is allowed to change its name)
+    iconUrl: '', // Link to bot profile picture (only works if bot is allowed to change image)
+    iconEmoji: 'laughing',  // An emoji tag without the ':'s for bot profile picture (only works if bot is allowed to change image)
+    displayedErrorsLimit: 25, // Limit the number of errors displayed in one message
+  }
+}
+```
+
+To personalise the bot, note the following from: https://docs.mattermost.com/developer/webhooks-incoming.html
+
+> Enable integrations to override usernames must be set to true in config.json to override
+> usernames. Enable them from System Console > Integrations > Custom Integrations in prior
+> versions or System Console > Integrations > Integration Management in versions after 5.12 or
+> ask your System Administrator to do so. If not enabled, the username is set to webhook.
+>
+> Similarly, Enable integrations to override profile picture icons must be set to true in
+> config.json to override profile picture icons. Enable them from
+> System Console > Integrations > Custom Integrations in prior versions or
+> System Console > Integrations > Integration Management in versions after 5.12 or ask your
+> System Administrator to do so. If not enabled, the icon of the creator of the webhook URL is
+> used to post messages.
+
+_Example_:
+
+![Mattermost notification](https://restqa.io/assets/img/utils/cucumber-export-mattermost.png)
+
 ###### Elastic-Search
 
 Export the result to an elastic search server (using rolling index)
@@ -299,6 +339,21 @@ let envConfig = {
         reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one,
         tts: false, // enable TTS for the message, false by default
         username: 'bot-name' //  alternative name for bot, uses the name it has in discord UI by default if nothing specified
+      }
+    },
+    {
+      type: 'mattermost',
+      enabled: true,
+      config: {
+        url: 'https://your-mattermost-url/webhooks/xxx',
+        onlyFailed: true // Trigger the hook only for test failure  (default: false),
+        showErrors: true // Show the error message within Mattermost,
+        reportUrl: 'https://www.test.report/{uuid}', // The url to access to your detail test report if you have one
+        channel: 'town-square', // The channel to send messages to
+        username: 'restqa-formatter', // Username to post as (only works if bot is allowed to change its name)
+        iconUrl: '', // Link to bot profile picture (only works if bot is allowed to change image)
+        iconEmoji: 'laughing',  // An emoji tag without the ':'s for bot profile picture (only works if bot is allowed to change image)
+        displayedErrorsLimit: 25 // Limit the number of errors displayed in one message
       }
     }
   ]

--- a/src/reports/index.js
+++ b/src/reports/index.js
@@ -6,5 +6,6 @@ module.exports = {
   slack: require('./slack'),
   'microsoft-teams': require('./microsoft-teams'),
   discord: require('./discord'),
-  line: require('./line')
+  line: require('./line'),
+  mattermost: require('./mattermost')
 }

--- a/src/reports/index.test.js
+++ b/src/reports/index.test.js
@@ -1,7 +1,7 @@
 describe('#services - Channels', () => {
   test('init module', () => {
     const index = require('./index')
-    expect(Object.keys(index).length).toEqual(8)
+    expect(Object.keys(index).length).toEqual(9)
     expect(Object.keys(index)).toEqual([
       'http',
       'http-html-report',
@@ -10,7 +10,8 @@ describe('#services - Channels', () => {
       'slack',
       'microsoft-teams',
       'discord',
-      'line'
+      'line',
+      'mattermost'
     ])
   })
 })

--- a/src/reports/mattermost.js
+++ b/src/reports/mattermost.js
@@ -1,0 +1,134 @@
+const got = require('got')
+const Errors = require('../errors')
+
+module.exports = function (config, result) {
+  return new Promise((resolve, reject) => {
+    try {
+      if (undefined === config.onlyFailed) {
+        config.onlyFailed = true
+      }
+
+      if (!config.url) { return reject(new Error('config.url is required for the "mattermost" report')) }
+
+      const url = new URL(config.url)
+
+      if (config.onlyFailed === true && result.success === true) { return resolve('[MATTERMOST] No notification is required because eveything is fine :)') }
+
+      const getStepsError = function () {
+        return result.features
+          .filter((_) => !_.result)
+          .map((feature) => {
+            return feature.elements
+              .filter((_) => !_.result)
+              .map((scenario) => {
+                const step = scenario.steps.find((_) => _.result.status === 'failed')
+                if (!step) return
+                return {
+                  title: `📕 Feature: ${feature.feature_name}`,
+                  value: `**Scenario: ** ${scenario.name}
+**Failed Step: ** ${step.keyword} ${step.name} (Line ${step.line})
+${'```'}
+${step.result.error_message}
+${'```'}`
+                }
+              })
+              .filter((_) => _)
+          })
+          .flat()
+      }
+
+      const status = result.success ? 'Passed' : 'Failed'
+      const attachment = {
+        author_name: '@restqa',
+        author_link: 'https://restqa.io',
+        author_icon: 'https://restqa.io/assets/img/favicon.png',
+        title: `The test suite *${status} (${result.passed}/${result.total})*`,
+        color: result.success ? '#007a5a' : '#ff0000',
+        fields: [
+          {
+            short: true,
+            title: 'Name',
+            value: `${result.name || ''}`
+          },
+          {
+            short: true,
+            title: 'Key',
+            value: `${result.key || ''}`
+          },
+          {
+            short: true,
+            title: 'Environment',
+            value: `${result.env || ''}`
+          },
+          {
+            short: true,
+            title: 'Execution Id',
+            value: `${result.id || ''}`
+          },
+          {
+            title: 'Scenarios',
+            value: `* Passed: ${result.scenarios.passed}
+* Failed: ${result.scenarios.failed}
+* Skipped: ${result.scenarios.skipped}
+* Undefined: ${result.scenarios.undefined}`
+          }
+        ],
+        thumb_url: `https://restqa.io/assets/img/utils/restqa-logo-${status.toLowerCase()}.png`
+      }
+
+      if (config.showErrors) {
+        const errors = getStepsError()
+        const displayedErrorsLimit = config.displayedErrorsLimit || 25
+
+        attachment.fields = attachment.fields.concat(errors.slice(0, displayedErrorsLimit))
+
+        if (errors.length > displayedErrorsLimit) {
+          attachment.fields = attachment.fields.concat({
+            title: '',
+            value: `*${errors.length - displayedErrorsLimit} hidden errors*`
+          })
+        }
+      }
+
+      if (config.reportUrl) {
+        const section = {
+          title: '',
+          value: `📊 <${config.reportUrl.replace('{uuid}', result.id)}|View test report>`
+        }
+        attachment.fields = attachment.fields.concat(section)
+      }
+
+      const data = Object.entries({
+        channel: config.channel,
+        username: config.username,
+        iconUrl: config.iconUrl,
+        iconEmoji: config.iconEmoji,
+        attachments: [attachment]
+      })
+        .filter((entry) => entry[1] != null)
+        .reduce((obj, entry) => {
+          obj[entry[0]] = entry[1]
+          return obj
+        }, {})
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port,
+        protocol: url.protocol,
+        pathname: url.pathname,
+        method: 'POST',
+        body: JSON.stringify(data)
+      }
+
+      got(options)
+        .then((res) => {
+          resolve(`[MATTERMOST REPORT][${res.statusCode}] - ${config.url}`)
+        })
+        .catch((err) => {
+          reject(new Errors.HTTP('MATTERMOST REPORT', err))
+        })
+    } catch (e) {
+      reject(new Errors.DEFAULT('MATTERMOST REPORT', e))
+    }
+  })
+}

--- a/src/reports/mattermost.test.js
+++ b/src/reports/mattermost.test.js
@@ -1,0 +1,411 @@
+let testResult = {}
+
+beforeEach(() => {
+  jest.resetModules()
+  testResult = {
+    id: 'xxx-yyy-zzz',
+    name: 'my test result',
+    env: 'local',
+    key: 'MY-KEY',
+    success: true,
+    total: 10,
+    passed: 10,
+    failed: 0,
+    scenarios: {
+      passed: 50,
+      failed: 0,
+      skipped: 10,
+      undefined: 0
+    }
+  }
+})
+
+describe('#report - MATTERMOST', () => {
+  test("Rejected if the config doesn't contain the url", () => {
+    const Mattermost = require('./mattermost')
+    const config = {}
+    const result = {}
+    expect(Mattermost(config, result)).rejects.toThrow(
+      new Error('config.url is required for the "mattermost" report')
+    )
+  })
+
+  test('Resolved if the config only specify notification for failure', () => {
+    const got = require('got')
+    jest.mock('got')
+
+    const Mattermost = require('./mattermost')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: true
+    }
+
+    const result = {
+      success: true
+    }
+
+    expect(Mattermost(config, result)).resolves.toBe(
+      '[MATTERMOST] No notification is required because eveything is fine :)'
+    )
+    expect(got.mock.calls.length).toBe(0)
+  })
+
+  test('Rejected if an issue occured', () => {
+    const Errors = require('../errors')
+
+    const Mattermost = require('./mattermost')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    testResult.scenarios = null
+
+    expect(Mattermost(config, testResult)).rejects.toThrow(
+      new Errors.DEFAULT('MATTERMOST REPORT', new Error("Cannot read property 'passed' of null"))
+    )
+  })
+
+  test('Rejected if the request fail', () => {
+    const Errors = require('../errors')
+    const got = require('got')
+    jest.mock('got')
+    const gotError = new Error('got Msg')
+    gotError.response = {
+      statusCode: 503,
+      body: {
+        err: 'foo/bar'
+      }
+    }
+
+    got.mockRejectedValue(gotError)
+
+    const Mattermost = require('./mattermost')
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false
+    }
+
+    expect(Mattermost(config, testResult)).rejects.toThrow(
+      new Errors.HTTP('MATTERMOST REPORT', gotError)
+    )
+
+    const MattermostExpect = {
+      attachments: [
+        {
+          author_name: '@restqa',
+          author_link: 'https://restqa.io',
+          author_icon: 'https://restqa.io/assets/img/favicon.png',
+          title: 'The test suite *Passed (10/10)*',
+          color: '#007a5a',
+          fields: [
+            {
+              short: true,
+              title: 'Name',
+              value: 'my test result'
+            },
+            {
+              short: true,
+              title: 'Key',
+              value: 'MY-KEY'
+            },
+            {
+              short: true,
+              title: 'Environment',
+              value: 'local'
+            },
+            {
+              short: true,
+              title: 'Execution Id',
+              value: 'xxx-yyy-zzz'
+            },
+            {
+              title: 'Scenarios',
+              value: `* Passed: 50
+* Failed: 0
+* Skipped: 10
+* Undefined: 0`
+            }
+          ],
+          thumb_url: 'https://restqa.io/assets/img/utils/restqa-logo-passed.png'
+        }
+      ]
+    }
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(MattermostExpect)
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+
+  test('Success case with config.showError = true, and report link)', () => {
+    const got = require('got')
+    jest.mock('got')
+    got.mockResolvedValue({
+      statusCode: 201,
+      body: {
+        result: 'ok'
+      }
+    })
+
+    const Mattermost = require('./mattermost')
+
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false,
+      showErrors: true,
+      reportUrl: 'http://url-of-the-report/{uuid}'
+    }
+
+    testResult.success = false
+    testResult.passed = 9
+    testResult.failed = 1
+    testResult.scenarios.passed = 49
+    testResult.scenarios.failed = 1
+    testResult.features = [
+      {
+        feature_name: 'Feature name',
+        elements: [
+          {
+            name: 'This is scenario name',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue',
+                line: 45,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    expect(Mattermost(config, testResult)).resolves.toBe(
+      '[MATTERMOST REPORT][201] - http://my-url.test/report'
+    )
+
+    const MattermostExpect = {
+      attachments: [
+        {
+          author_name: '@restqa',
+          author_link: 'https://restqa.io',
+          author_icon: 'https://restqa.io/assets/img/favicon.png',
+          title: 'The test suite *Failed (9/10)*',
+          color: '#ff0000',
+          fields: [
+            {
+              short: true,
+              title: 'Name',
+              value: 'my test result'
+            },
+            {
+              short: true,
+              title: 'Key',
+              value: 'MY-KEY'
+            },
+            {
+              short: true,
+              title: 'Environment',
+              value: 'local'
+            },
+            {
+              short: true,
+              title: 'Execution Id',
+              value: 'xxx-yyy-zzz'
+            },
+            {
+              title: 'Scenarios',
+              value: `* Passed: 49
+* Failed: 1
+* Skipped: 10
+* Undefined: 0`
+            },
+            {
+              title: '📕 Feature: Feature name',
+              value: `**Scenario: ** This is scenario name
+**Failed Step: ** When i have an issue (Line 45)
+${'```'}
+Not working
+${'```'}`
+            },
+            {
+              title: '',
+              value: '📊 <http://url-of-the-report/xxx-yyy-zzz|View test report>'
+            }
+          ],
+          thumb_url: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png'
+        }
+      ]
+    }
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(MattermostExpect)
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+
+  test('Fail case with config.displayedErrorsLimit = 1 and 3 fails, Result should show only 1 fail)', () => {
+    const got = require('got')
+    jest.mock('got')
+    got.mockResolvedValue({
+      statusCode: 201,
+      body: {
+        result: 'ok'
+      }
+    })
+
+    const Mattermost = require('./mattermost')
+
+    const config = {
+      url: 'http://my-url.test/report',
+      onlyFailed: false,
+      showErrors: true,
+      displayedErrorsLimit: 1,
+      reportUrl: 'http://url-of-the-report/{uuid}'
+    }
+
+    testResult.success = false
+    testResult.passed = 7
+    testResult.failed = 3
+    testResult.scenarios.passed = 47
+    testResult.scenarios.failed = 3
+    testResult.features = [
+      {
+        feature_name: 'Feature name',
+        elements: [
+          {
+            name: 'This is scenario name 1',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue',
+                line: 45,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working 1'
+                }
+              }
+            ]
+          },
+          {
+            name: 'This is scenario name 2',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue 2',
+                line: 50,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working 2'
+                }
+              }
+            ]
+          },
+          {
+            name: 'This is scenario name 3',
+            steps: [
+              {
+                keyword: 'When',
+                name: 'i have an issue 3',
+                line: 55,
+                result: {
+                  status: 'failed',
+                  error_message: 'Not working 3'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    expect(Mattermost(config, testResult)).resolves.toBe(
+      '[MATTERMOST REPORT][201] - http://my-url.test/report'
+    )
+
+    const MattermostExpect = {
+      attachments: [
+        {
+          author_name: '@restqa',
+          author_link: 'https://restqa.io',
+          author_icon: 'https://restqa.io/assets/img/favicon.png',
+          title: 'The test suite *Failed (7/10)*',
+          color: '#ff0000',
+          fields: [
+            {
+              short: true,
+              title: 'Name',
+              value: 'my test result'
+            },
+            {
+              short: true,
+              title: 'Key',
+              value: 'MY-KEY'
+            },
+            {
+              short: true,
+              title: 'Environment',
+              value: 'local'
+            },
+            {
+              short: true,
+              title: 'Execution Id',
+              value: 'xxx-yyy-zzz'
+            },
+            {
+              title: 'Scenarios',
+              value: `* Passed: 47
+* Failed: 3
+* Skipped: 10
+* Undefined: 0`
+            },
+            {
+              title: '📕 Feature: Feature name',
+              value: `**Scenario: ** This is scenario name 1
+**Failed Step: ** When i have an issue (Line 45)
+${'```'}
+Not working 1
+${'```'}`
+            },
+            {
+              title: '',
+              value: '*2 hidden errors*'
+            },
+            {
+              title: '',
+              value: '📊 <http://url-of-the-report/xxx-yyy-zzz|View test report>'
+            }
+          ],
+          thumb_url: 'https://restqa.io/assets/img/utils/restqa-logo-failed.png'
+        }
+      ]
+    }
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      body: JSON.stringify(MattermostExpect)
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+})


### PR DESCRIPTION
There's an additional parameter attached to the config object `displayedErrorsLimit` that I implemented to limit the amount of text in one message block

Unlike Slack or Teams, this platform doesn't collapse long text (as far as I have seen) so that option exists to manually cap things.

There's also more hoops to jump through to customise the bot names etc:

https://docs.mattermost.com/developer/webhooks-incoming.html

I've added a note in the readme