### PR TITLE
http-html-report : allow basic auth as a custom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,11 @@ Basically you have 2 options to use this reporter.]:
   type: 'http-html-report',
   enabled: true,
   config: {
-    url: 'https://html-report.your-domain.dev' // (default : https://html-report.restqa.io)
+    url: 'https://html-report.your-domain.dev' // (default : https://html-report.restqa.io),
+    auth: { // Authentication through basic auth
+      username: 'olive',
+      password: 'test'
+    }
   }
 }
 ```

--- a/src/reports/http-html-report.js
+++ b/src/reports/http-html-report.js
@@ -18,13 +18,13 @@ module.exports = function (config, result) {
     }
 
     if (config.auth) {
-      let {
+      const {
         username,
         password
       } = config.auth
 
       options.headers = {
-        authorization: `Basic ${Buffer.from(username + ':' + password, "utf8").toString("base64")}`
+        authorization: `Basic ${Buffer.from(username + ':' + password, 'utf8').toString('base64')}`
       }
     }
 

--- a/src/reports/http-html-report.js
+++ b/src/reports/http-html-report.js
@@ -15,7 +15,17 @@ module.exports = function (config, result) {
       pathname: url.pathname,
       method: 'POST',
       json: result
+    }
 
+    if (config.auth) {
+      let {
+        username,
+        password
+      } = config.auth
+
+      options.headers = {
+        authorization: `Basic ${Buffer.from(username + ':' + password, "utf8").toString("base64")}`
+      }
     }
 
     got(options)

--- a/src/reports/http-html-report.test.js
+++ b/src/reports/http-html-report.test.js
@@ -73,6 +73,46 @@ describe('#report - HTTP HTML REPORT', () => {
     expect(got.mock.calls[0][0]).toEqual(expectedOptions)
   })
 
+  test('Success Case with basic auth', () => {
+    const got = require('got')
+    jest.mock('got')
+    got.mockResolvedValue({
+      statusCode: 201
+    })
+
+    const HttpHtmlReport = require('./http-html-report')
+    const config = {
+      url: 'http://my-url.test/report',
+      auth: {
+        username: 'admin',
+        password: 'test'
+      }
+    }
+
+    const result = {
+      id: 'qqq-www-eee',
+      success: true
+    }
+    expect(HttpHtmlReport(config, result)).resolves.toBe('[HTTP HTML REPORT][201] - Access to your test report : http://my-url.test/report/qqq-www-eee')
+
+    const expectedOptions = {
+      hostname: 'my-url.test',
+      port: '',
+      protocol: 'http:',
+      pathname: '/report',
+      method: 'POST',
+      json: {
+        id: 'qqq-www-eee',
+        success: true
+      },
+      headers: {
+        authorization: `Basic ${Buffer.from('admin:test').toString('base64')}`
+      }
+    }
+    expect(got.mock.calls.length).toBe(1)
+    expect(got.mock.calls[0][0]).toEqual(expectedOptions)
+  })
+
   test('Success Case using default html report from restqa', () => {
     const got = require('got')
     jest.mock('got')


### PR DESCRIPTION
Add an extra custom option on the reporter http-html-report in order to setup the basic auth authorization

Resolve #24 